### PR TITLE
fix: save each trait in a separate file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eggla
 Title: Early Growth Genetics Longitudinal Analysis
-Version: 0.10.4
+Version: 0.10.4.9000
 Authors@R:
     c(person(given = "Mickaël",
            family = "Canouil",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# eggla (development version)
+
 # eggla 0.10.4
 
 ## Fixes


### PR DESCRIPTION
This PR closes #23

In addition, `do_eggla_gwas()` now export the derived parameters "alone" (without the model object as with `run_eggla()`.