### PR TITLE
fix: non unique ids

### DIFF
--- a/R/compute_apar.R
+++ b/R/compute_apar.R
@@ -79,20 +79,18 @@ compute_apar <- function(fit, from = c("predicted", "observed"), start = 0.25, e
     f <- identity
   }
 
-  out <- switch(EXPR = from,
-    "observed" = {
-      data.table::as.data.table(fit[["data"]])[
-        j = .SD,
-        .SDcols = c(id_var, age_var, bmi_var)
-      ]
-    },
-    "predicted" = {
-      predict_bmi(fit = fit, start = start, end = end, step = step)
-    }
-  )
-
   data.table::setnames(
-    x = out,
+    x = switch(EXPR = from,
+      "observed" = {
+        data.table::as.data.table(fit[["data"]])[
+          j = .SD,
+          .SDcols = c(id_var, age_var, bmi_var)
+        ]
+      },
+      "predicted" = {
+        predict_bmi(fit = fit, start = start, end = end, step = step)
+      }
+    ),
     old = c(id_var, age_var, bmi_var, covariates),
     new = c("egg_id", "egg_ageyears", "egg_bmi", sprintf("egg_%s", covariates)),
     skip_absent = TRUE

--- a/R/run_eggla_lmm.R
+++ b/R/run_eggla_lmm.R
@@ -118,6 +118,18 @@ run_eggla_lmm <- function(
     intersect(covariates, names(data))
   )
 
+  if (anyDuplicated(
+    data[
+      j = list(id_not_unique = anyDuplicated(egg_agedays)),
+      by = c("egg_id", "egg_sex")
+    ][["id_unique"]]
+  )) {
+    stop(sprintf(
+      "It appears IDs provided by '%s' are not unique. 'id_variable' must be unique!",
+      id_variable
+    ))
+  }
+
   dt_long <- data.table::melt(
     data = data.table::as.data.table(data)[
       j = `:=`(

--- a/R/run_eggla_lmm.R
+++ b/R/run_eggla_lmm.R
@@ -118,14 +118,14 @@ run_eggla_lmm <- function(
     intersect(covariates, names(data))
   )
 
-  if (anyDuplicated(
+  if (sum(
     data[
       j = list(id_not_unique = anyDuplicated(egg_agedays)),
       by = c("egg_id", "egg_sex")
-    ][["id_unique"]]
-  )) {
+    ][["id_not_unique"]]
+  ) > 0) {
     stop(sprintf(
-      "It appears IDs provided by '%s' are not unique. 'id_variable' must be unique!",
+      "It appears IDs provided by column '%s' are not unique. 'id_variable' must be a column providing unique IDs!",
       id_variable
     ))
   }


### PR DESCRIPTION
This PR add a check in `run_eggla_gwas` to ensure individuals identifiers are unique on their own and not in combination with covariates.