### PR TITLE
fix: update step parameter in APAR

### DIFF
--- a/R/compute_apar.R
+++ b/R/compute_apar.R
@@ -60,7 +60,7 @@
 #'   by = "variable"
 #' ]
 #' wrap_plots(list_gg[["gg"]], guides = "collect")
-compute_apar <- function(fit, from = c("predicted", "observed"), start = 0.25, end = 10, step = 0.05, filter = NULL) {
+compute_apar <- function(fit, from = c("predicted", "observed"), start = 0.25, end = 10, step = 0.01, filter = NULL) {
   stopifnot(inherits(fit, "lme"))
   match.arg(from, c("predicted", "observed"))
   AP <- AR <- egg_ageyears <- egg_bmi <- egg_id <- apar <- NULL # no visible binding for global variable from data.table

--- a/R/compute_outliers.R
+++ b/R/compute_outliers.R
@@ -61,7 +61,7 @@ compute_outliers <- function(
   from = c("predicted", "observed"),
   start = 0.25,
   end = 10,
-  step = 0.05,
+  step = 0.01,
   filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2)

--- a/R/egg_correlations.R
+++ b/R/egg_correlations.R
@@ -36,7 +36,7 @@ egg_correlations <- function(
   start = 0.25,
   end = 10,
   step = 0.01,
-  filter = NULL,
+  filter = NULL
 ) {
   AP <- AR <- what <- NULL # no visible binding for global variable from data.table
   dt <- Reduce(

--- a/R/egg_correlations.R
+++ b/R/egg_correlations.R
@@ -10,9 +10,7 @@
 #'   such as from a call to `egg_model()`.
 #' @param period The intervals knots on which slopes are to be computed.
 #' @param knots The knots as defined `fit` and according to `method`.
-#' @param filter_apar A string following `data.table` syntax for filtering on `"i"`
-#'   (_i.e._, row elements), _e.g._, `filter = "source == 'A'"`.
-#'   Default is `NULL`.
+#' @inheritParams predict_bmi
 #'
 #' @return A `data.table` object with correlations between each intervals derived parameters.
 #'
@@ -35,7 +33,10 @@ egg_correlations <- function(
   fit,
   period = c(0, 0.5, 1.5, 3.5, 6.5, 10, 12, 17),
   knots = c(1, 8, 12),
-  filter_apar = NULL
+  start = 0.25,
+  end = 10,
+  step = 0.01,
+  filter = NULL,
 ) {
   AP <- AR <- what <- NULL # no visible binding for global variable from data.table
   dt <- Reduce(
@@ -49,10 +50,10 @@ egg_correlations <- function(
             data = compute_apar(
               fit = fit,
               from = "predicted",
-              start = 0.25,
-              end = 10,
-              step = 0.05,
-              filter = filter_apar
+              start = start,
+              end = end,
+              step = step,
+              filter = filter
             )[
               AP | AR
             ][

--- a/R/egg_outliers.R
+++ b/R/egg_outliers.R
@@ -48,7 +48,7 @@ egg_outliers <- function(
   from = c("predicted", "observed"),
   start = 0.25,
   end = 10,
-  step = 0.05,
+  step = 0.01,
   filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2)

--- a/R/predict_bmi.R
+++ b/R/predict_bmi.R
@@ -11,6 +11,7 @@
 #' @param step The step to increment the sequence.
 #' @param filter A string following `data.table` syntax for filtering on `"i"`
 #'   (_i.e._, row elements), _e.g._, `filter = "source == 'A'"`.
+#'   Argument pass through `compute_apar()` (see `predict_bmi()`).
 #'   Default is `NULL`.
 #'
 #' @return A `data.table` object.
@@ -43,7 +44,7 @@
 #' predict_bmi(res)[order(egg_id, egg_ageyears)]
 #'
 #' predict_bmi(res, filter = "source == 'A'")[order(egg_id, egg_ageyears)]
-predict_bmi <- function(fit, start = 0.25, end = 10, step = 0.05, filter = NULL) {
+predict_bmi <- function(fit, start = 0.25, end = 10, step = 0.01, filter = NULL) {
   stopifnot(inherits(fit, "lme"))
   bmi <- egg_ageyears <- egg_bmi <- egg_id <- NULL # no visible binding for global variable from data.table
 
@@ -115,7 +116,7 @@ predict_bmi <- function(fit, start = 0.25, end = 10, step = 0.05, filter = NULL)
   ) {
     warning(paste(
       "Multiple BMI measures (for the same age) have been detected and are aggregated using geometric mean!",
-      "Use \"filter\" (or \"filter_apar\" in `run_eggla_lmm()`) parameter to apply some filtering, e.g., filter = \"source == 'clinic'\".",
+      "Use \"filter\" (or \"filter\" in `run_eggla_lmm()`) parameter to apply some filtering, e.g., filter = \"source == 'clinic'\".",
       sep = "\n"
     ))
     out <- out[

--- a/R/run_eggla_lmm.R
+++ b/R/run_eggla_lmm.R
@@ -25,10 +25,7 @@
 #'   i.e., CAR(1) as correlation structure.
 #' @param knots The knots defining the splines.
 #' @param period The intervals knots on which slopes are to be computed.
-#' @param filter_apar A string following `data.table` syntax for filtering on `"i"`
-#'   (_i.e._, row elements), _e.g._, `filter = "source == 'A'"`.
-#'   Argument pass through `compute_apar()` (see `predict_bmi()`).
-#'   Default is `NULL`.
+#' @inheritParams predict_bmi
 #' @param outlier_method The outlier detection method(s). Default is `"iqr"`. Can be
 #'   `"cook"`, `"pareto"`, `"zscore"`, `"zscore_robust"`, `"iqr"`, `"ci"`, `"eti"`,
 #'   `"hdi"`, `"bci"`, `"mahalanobis"`, `"mahalanobis_robust"`, `"mcd"`, `"ics"`,
@@ -88,7 +85,10 @@ run_eggla_lmm <- function(
   use_car1 = FALSE,
   knots = c(1, 8, 12),
   period = c(0, 0.5, 1.5, 3.5, 6.5, 10, 12, 17),
-  filter_apar = NULL,
+  start = 0.25,
+  end = 10,
+  step = 0.01,
+  filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2),
   outlier_exclude = TRUE,
@@ -272,10 +272,10 @@ run_eggla_lmm <- function(
           data = compute_apar(
             fit = results,
             from = "predicted",
-            start = 0.25,
-            end = 10,
-            step = 0.05,
-            filter = filter_apar
+            start = start,
+            end = end,
+            step = step,
+            filter = filter
           )[
             AP | AR
           ][
@@ -323,10 +323,10 @@ run_eggla_lmm <- function(
         period = period,
         knots = knots,
         from = "predicted",
-        start = 0.25,
-        end = 10,
-        step = 0.05,
-        filter = filter_apar,
+        start = start,
+        end = end,
+        step = step,
+        filter = filter,
         outlier_method = outlier_method,
         outlier_threshold = outlier_threshold
       )

--- a/man/compute_apar.Rd
+++ b/man/compute_apar.Rd
@@ -9,7 +9,7 @@ compute_apar(
   from = c("predicted", "observed"),
   start = 0.25,
   end = 10,
-  step = 0.05,
+  step = 0.01,
   filter = NULL
 )
 }
@@ -28,6 +28,7 @@ computation, either "predicted" or "observed". Default is "predicted".}
 
 \item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
+Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}
 }
 \value{

--- a/man/compute_outliers.Rd
+++ b/man/compute_outliers.Rd
@@ -13,7 +13,7 @@ compute_outliers(
   from = c("predicted", "observed"),
   start = 0.25,
   end = 10,
-  step = 0.05,
+  step = 0.01,
   filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2)
@@ -41,6 +41,7 @@ computation, either "predicted" or "observed". Default is "predicted".}
 
 \item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
+Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}
 
 \item{outlier_method}{The outlier detection method(s). Default is \code{"iqr"}. Can be

--- a/man/egg_correlations.Rd
+++ b/man/egg_correlations.Rd
@@ -8,7 +8,10 @@ egg_correlations(
   fit,
   period = c(0, 0.5, 1.5, 3.5, 6.5, 10, 12, 17),
   knots = c(1, 8, 12),
-  filter_apar = NULL
+  start = 0.25,
+  end = 10,
+  step = 0.01,
+  filter = NULL
 )
 }
 \arguments{
@@ -19,8 +22,15 @@ such as from a call to \code{egg_model()}.}
 
 \item{knots}{The knots as defined \code{fit} and according to \code{method}.}
 
-\item{filter_apar}{A string following \code{data.table} syntax for filtering on \code{"i"}
+\item{start}{The start of the time window to compute AP and AR.}
+
+\item{end}{The end of the time window to compute AP and AR.}
+
+\item{step}{The step to increment the sequence.}
+
+\item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
+Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}
 }
 \value{

--- a/man/egg_outliers.Rd
+++ b/man/egg_outliers.Rd
@@ -11,7 +11,7 @@ egg_outliers(
   from = c("predicted", "observed"),
   start = 0.25,
   end = 10,
-  step = 0.05,
+  step = 0.01,
   filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2)
@@ -36,6 +36,7 @@ computation, either "predicted" or "observed". Default is "predicted".}
 
 \item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
+Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}
 
 \item{outlier_method}{The outlier detection method(s). Default is \code{"iqr"}. Can be

--- a/man/predict_bmi.Rd
+++ b/man/predict_bmi.Rd
@@ -4,7 +4,7 @@
 \alias{predict_bmi}
 \title{Predict BMI for a range of ages from a model fit.}
 \usage{
-predict_bmi(fit, start = 0.25, end = 10, step = 0.05, filter = NULL)
+predict_bmi(fit, start = 0.25, end = 10, step = 0.01, filter = NULL)
 }
 \arguments{
 \item{fit}{A model object from a statistical model
@@ -18,6 +18,7 @@ such as from a call \code{nlme::lme()}, \code{time_model()} or \code{egg_model()
 
 \item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
+Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}
 }
 \value{

--- a/man/run_eggla_lmm.Rd
+++ b/man/run_eggla_lmm.Rd
@@ -18,7 +18,10 @@ run_eggla_lmm(
   use_car1 = FALSE,
   knots = c(1, 8, 12),
   period = c(0, 0.5, 1.5, 3.5, 6.5, 10, 12, 17),
-  filter_apar = NULL,
+  start = 0.25,
+  end = 10,
+  step = 0.01,
+  filter = NULL,
   outlier_method = "iqr",
   outlier_threshold = list(iqr = 2),
   outlier_exclude = TRUE,
@@ -61,7 +64,13 @@ i.e., CAR(1) as correlation structure.}
 
 \item{period}{The intervals knots on which slopes are to be computed.}
 
-\item{filter_apar}{A string following \code{data.table} syntax for filtering on \code{"i"}
+\item{start}{The start of the time window to compute AP and AR.}
+
+\item{end}{The end of the time window to compute AP and AR.}
+
+\item{step}{The step to increment the sequence.}
+
+\item{filter}{A string following \code{data.table} syntax for filtering on \code{"i"}
 (\emph{i.e.}, row elements), \emph{e.g.}, \code{filter = "source == 'A'"}.
 Argument pass through \code{compute_apar()} (see \code{predict_bmi()}).
 Default is \code{NULL}.}


### PR DESCRIPTION
This PR:

- propagate `predict_bmi()` parameters to parent functions leading to a **breaking change**, _i.e._, `filter_apar` has been renamed `filter`.
- Default `step` parameter associated with `predict_bmi()` and all related functions has been changed from `0.05` to `0.01`.