### PR TITLE
build: update PLINK2 to 11th of April 2023 version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eggla
 Title: Early Growth Genetics Longitudinal Analysis
-Version: 0.19.1.9000
+Version: 0.19.2
 Authors@R:
     c(person(given = "Mickaël",
            family = "Canouil",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,16 @@
-# eggla (development version)
+# eggla 0.19.2
+
+## Build
+
+- In `inst/bin`,
+  - build: update PLINK2 to 11th of April 2023 version (Linux 64-bit build).
 
 ## Chores
 
 - In `inst/CITATION`,
   - chore: convert to `bibentry`.
+
+**Full Changelog**: <https://github.com/mcanouil/eggla/compare/v0.19.1...v0.19.2>
 
 # eggla 0.19.1
 


### PR DESCRIPTION
This PR update PLINK2 version used internaly to get the below bugs fix.

> 11 Apr 2023: --gwas-ssf command added, which (re)formats --glm output for submission to the GWAS Catalog. QUAL values are now allowed to be infinity. --adjust-file should now work properly on files with no TEST column. 'maybeprovref' and 'provref' optional column sets added to many commands. Built-in zstd version updated to 1.5.5, which fixes a very rare corruption bug for --zst-level 16+.
This is a candidate for the final alpha 4(.0) build.
> 
> 29 Mar: Fixed a rare multiallelic-variant .pgen writing bug that could result in an obviously-corrupted .pgen (--validate reports unexpected file size) when REF and ALT1 frequencies are both low.
> 
> 25 Mar: Fixed --indep-pairwise chrX bug that occurred when some nonfounders were present. --indep-pairwise speed improvement. --indep-order flag added; "--indep-order 2" greatly speeds up --indep-pairwise while slightly changing results, and will become the default in the future. --glm 'provref' optional column set added, distinguishing provisional from known reference alleles; this will be included in the default column set in the future.
> 
> 3 Mar: Fixed --hardy/--hwe bug that could cause a segfault when chrX and multiallelic variants are present, and sex information is absent. --glm 'omitted' optional column set added, listing only the omitted allele; this (and 'a1freq') will be included in the default column set in the future. --glm 'ax' column set deprecated. Linux builds now avoid requesting more memory than reported by /proc/meminfo's 'MemAvailable' entry (when it exists). --pca now prints a more informative error message when there is a nan in the GRM.