### PR TITLE
fix: turns warnings into errors temporarily and internally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eggla
 Title: Early Growth Genetics Longitudinal Analysis
-Version: 0.19.4
+Version: 0.19.5
 Authors@R:
     c(person(given = "Mickaël",
            family = "Canouil",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# eggla 0.19.5
+
+## Fixes
+
+- In `R/egg_model.R`,
+  - fix: turns warnings into errors when fitting the model for the first time.
+
+**Full Changelog**: <https://github.com/mcanouil/eggla/compare/v0.19.4...v0.19.5>
+
 # eggla 0.19.4
 
 ## Fixes

--- a/R/egg_model.R
+++ b/R/egg_model.R
@@ -130,10 +130,17 @@ egg_model <- function(
       )
     }
 
+    # To avoid complexity of the code, we use `try()` to catch errors and warnings
+    # by temporarily setting `options(warn = 2)`, which turns warnings into errors.
+    # Then, we set back the original value of `options(warn)`.
+    # This is not ideal, but it works.
+    opt_warn <- getOption("warn")
+    options(warn = 2)
     res_model <- try(
       expr = eval(parse(text = paste(model_call, collapse = ""))),
       silent = TRUE
     )
+    options(warn = opt_warn)
 
     if (inherits(res_model, "try-error")) {
       if (!quiet) {


### PR DESCRIPTION
To avoid complexity of the code, we use `try()` to catch errors and warnings by temporarily setting `options(warn = 2)`, which turns warnings into errors.
Then, we set back the original value of `options(warn)`.
This is not ideal, but it works.

Fixes #110