### PR TITLE
docs: update install instructions and rm outdated email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eggla
 Title: Early Growth Genetics Longitudinal Analysis
-Version: 1.0.3
+Version: 1.0.4
 Authors@R:
     c(person(given = "Mickaël",
            family = "Canouil",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# eggla 1.0.4
+
+## Documentation
+
+- In `README.Rmd`,
+  - docs: replace previous instructions with instructions using "lock" file for dependencies.
+- In `vignettes/`,
+  - docs: remove outdated email address.
+
 # eggla 1.0.3
 
 ## Fixes

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,23 +19,37 @@ Tools for longitudinal analysis within the [EGG (Early Growth Genetics) Consorti
 
 ## Installation
 
-* Install the development version from GitHub:
+* Install [`pak`](https://pak.r-lib.org/)
 
-```{r}
-#| eval: false
-# install.packages("remotes")
-remotes::install_github("mcanouil/eggla")
-```
+  ```r
+  temp_library <- file.path(".", "R")
+  dir.create(temp_library, recursive = TRUE)
+  .libPaths(temp_library)
+  utils::install.packages(
+    pkgs = "pak",
+    lib = temp_library,
+    repos = sprintf(
+      "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+      .Platform[["pkgType"]], R.Version()[["os"]], R.Version()[["arch"]]
+    )
+  )
+  ```
 
-* Install a particular version:
+* Install `eggla` and its dependencies
 
-```{r}
-#| eval: false
-# install.packages("remotes")
-remotes::install_github("mcanouil/eggla@v1.0.0")
-# or the latest stable version
-remotes::install_github("mcanouil/eggla@latest")
-```
+  ```r
+  library(pak)
+  VERSION <- "latest"
+  utils::download.file(
+    url = sprintf(
+      "https://raw.githubusercontent.com/mcanouil/eggla/%s/.github/.devcontainer/eggla/R/pkg.lock",
+      VERSION
+    ),
+    destfile = "pkg.lock"
+  )
+  lockfile_install(lockfile = "pkg.lock", lib = temp_library)
+  pkg_install(sprintf("mcanouil/eggla@%s", VERSION), lib = temp_library, upgrade = FALSE, dependencies = FALSE)
+  ```
 
 ## Docker Images
 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,37 @@ Consortium](http://egg-consortium.org/).
 
 ## Installation
 
-- Install the development version from GitHub:
+- Install [`pak`](https://pak.r-lib.org/)
 
-``` r
-# install.packages("remotes")
-remotes::install_github("mcanouil/eggla")
-```
+  ``` r
+  temp_library <- file.path(".", "R")
+  dir.create(temp_library, recursive = TRUE)
+  .libPaths(temp_library)
+  utils::install.packages(
+    pkgs = "pak",
+    lib = temp_library,
+    repos = sprintf(
+      "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+      .Platform[["pkgType"]], R.Version()[["os"]], R.Version()[["arch"]]
+    )
+  )
+  ```
 
-- Install a particular version:
+- Install `eggla` and its dependencies
 
-``` r
-# install.packages("remotes")
-remotes::install_github("mcanouil/eggla@v1.0.0")
-# or the latest stable version
-remotes::install_github("mcanouil/eggla@latest")
-```
+  ``` r
+  library(pak)
+  VERSION <- "latest"
+  utils::download.file(
+    url = sprintf(
+      "https://raw.githubusercontent.com/mcanouil/eggla/%s/.github/.devcontainer/eggla/R/pkg.lock",
+      VERSION
+    ),
+    destfile = "pkg.lock"
+  )
+  lockfile_install(lockfile = "pkg.lock", lib = temp_library)
+  pkg_install(sprintf("mcanouil/eggla@%s", VERSION), lib = temp_library, upgrade = FALSE, dependencies = FALSE)
+  ```
 
 ## Docker Images
 

--- a/vignettes/articles/adiposity-peak-rebound.Rmd
+++ b/vignettes/articles/adiposity-peak-rebound.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Adiposity Peak & Adiposity Rebound Caracterisation"
-author: "Mickaël Canouil, *Ph.D.* (<mickael.canouil@cnrs.fr>)"
+author: "Mickaël Canouil, *Ph.D.*"
 params:
   working_directory: !expr tempdir()
 ---

--- a/vignettes/articles/model-selection.Rmd
+++ b/vignettes/articles/model-selection.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Model Selection"
-author: "Mickaël Canouil, *Ph.D.* (<mickael.canouil@cnrs.fr>)"
+author: "Mickaël Canouil, *Ph.D.*"
 params:
   working_directory: !expr tempdir()
 ---

--- a/vignettes/articles/models-diagnostics.Rmd
+++ b/vignettes/articles/models-diagnostics.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Models Diagnostics"
-author: "Mickaël Canouil, *Ph.D.* (<mickael.canouil@cnrs.fr>)"
+author: "Mickaël Canouil, *Ph.D.*"
 ---
 
 ```{r}

--- a/vignettes/articles/run-cubic-splines.Rmd
+++ b/vignettes/articles/run-cubic-splines.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Run The Cubic Splines (Random Cubic/Linear Splines) Analysis"
-author: "Mickaël Canouil, *Ph.D.* (<mickael.canouil@cnrs.fr>)"
+author: "Mickaël Canouil, *Ph.D.*"
 ---
 
 ```{r}

--- a/vignettes/eggla.Rmd
+++ b/vignettes/eggla.Rmd
@@ -2,7 +2,7 @@
 title: "Get Started with 'eggla'"
 description: |
   How-to run the 'eggla' workflow from quality-control to genome-wide association study.
-author: "Mickaël Canouil, *Ph.D.* (<mickael.canouil@cnrs.fr>)"
+author: "Mickaël Canouil, *Ph.D.*"
 output: 
   rmarkdown::html_vignette:
     number_sections: true


### PR DESCRIPTION
This pull request includes several updates to the documentation and installation instructions for the `eggla` package. The changes update the package version, improve the installation instructions by using/showing a "lock" file for dependencies, and remove outdated email addresses from the vignettes.

Documentation updates:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3): Updated the package version from 1.0.3 to 1.0.4.
* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR1-R9): Added a new section for version 1.0.4, detailing the documentation updates.

Installation instructions:

* [`README.Rmd`](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL22-R51): Revised the installation instructions to use the `pak` package and a "lock" file for dependencies.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R51): Updated the installation instructions similarly to `README.Rmd` to ensure consistency.

Vignettes:

* Removed outdated email addresses from the author field in multiple vignette files (`adiposity-peak-rebound.Rmd`, `model-selection.Rmd`, `models-diagnostics.Rmd`, `run-cubic-splines.Rmd`, `eggla.Rmd`). [[1]](diffhunk://#diff-ef9da2083823127f1d2484dccc142738d2d2efaee5ced28f8b648645a3447fefL3-R3) [[2]](diffhunk://#diff-cbe576ee47b12b7e4d7f58cdb2a05978f46d38654d72b57c5a30078a61a51d71L3-R3) [[3]](diffhunk://#diff-402ffaafa84d6fd7f45ee3dd5ffdab96869e5ffc2d2cc22b7d520230e42e64fcL3-R3) [[4]](diffhunk://#diff-cdaa63afc35042eb467af339175ebf5d9be798673378f408931f1d9a470e480eL3-R3) [[5]](diffhunk://#diff-2c4ade7a5c2ceccf1186662d241e42b2c99b59ae4f0f2188b8a619540b02c57eL5-R5)